### PR TITLE
Fix ATtiny85_45_25 wrapping other boards

### DIFF
--- a/PSNee_V8/PSNee_V8/MUC.h
+++ b/PSNee_V8/PSNee_V8/MUC.h
@@ -340,7 +340,7 @@
 #define PIN_SUBQ_READ              (PINB   &   (1<<PINB1))                      
 #define PIN_WFCK_READ              (PINB   &   (1<<PINB4))      
 
-#defintu conais les attiny 414e TIMER_INTERRUPT_ENABLE      TIMSK |=  (1<<OCIE0A)
+#define TIMER_INTERRUPT_ENABLE      TIMSK |=  (1<<OCIE0A)
 #define TIMER_INTERRUPT_DISABLE     TIMSK &= ~(1<<OCIE0A)
 
 #if !defined(SCPH_xxx1) && !defined(SCPH_xxx2) && !defined(SCPH_103)

--- a/PSNee_V8/PSNee_V8/MUC.h
+++ b/PSNee_V8/PSNee_V8/MUC.h
@@ -347,6 +347,8 @@
  #error "ATtiny85_45_25 Not compatible with BIOS patch, please choose a compatible SCPH. For example: SCPH_xxx1: SCPH_xxx2: SCPH_103"
 #endif
 
+#endif
+
 #ifdef ATtiny88_48
 
 #define F_CPU 16000000L
@@ -636,7 +638,5 @@
 #define PIN_SWITCH_INPUT            GPIOA->MODER &= ~(GPIO_MODER_MODER5)                              
 #define PIN_SWITCH_SET              GPIOA->ODR  |=  (GPIO_ODR_ODR_5)                                
 #define PIN_SWICHE_READ            (GPIOA->IDR   &   (GPIO_IDR_IDR_5))
-
-#endif
 
 #endif


### PR DESCRIPTION
Hey! I recently tested the `test2` branch with a Nano clone board (programmed via ICSP), and it's currently working pretty nicely on my NTSC/U PU-18. I tested an APv2 game, and it seems fully stealth. Thanks! 😄 

I want to test it using an ATTiny45, and while reading the code, I found a couple of issues:
- 5467cddbb9ee30402aa73446dba03d3e8f8c8776: The `#ifdef ATtiny85_45_25` was closing at the end of the file, wrapping inside of it all of the next boards (`ATtiny88_48`, `ATtiny214_414`, and `CH32V003`). I just moved the `#endif` statement to wrap up before `ATtiny88_48` fixes it.
- 2b154407d1733fa842cebec0b10874e5da8b4653: Cleaned up the `TIMER_INTERRUPT_ENABLE` definition.